### PR TITLE
 Add Dockerized Grafana Setup for Hosted PostgreSQL Metrics Monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,6 @@
 version: '3.8'
 
 services:
-  postgres:
-    image: postgres:15
-    container_name: postgres
-    environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: metrics_db
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
@@ -21,11 +9,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     ports:
       - "3000:3000"
-    depends_on:
-      - postgres
     volumes:
       - grafana_data:/var/lib/grafana
 
 volumes:
-  postgres_data:
   grafana_data:


### PR DESCRIPTION
<img width="1511" alt="Screenshot 2568-06-24 at 13 23 49" src="https://github.com/user-attachments/assets/9ccded54-8696-49dd-8f8d-c5e107e00d2f" />

### **Description:**
This PR introduces a Dockerized setup for Grafana, configured to connect to a hosted PostgreSQL server for metrics monitoring. The following changes and configurations have been implemented:

1. **Dockerized Grafana:**
   - Added a docker-compose.yml file to run Grafana in a Docker container.
   - Configured Grafana to expose its UI on port `3000`.

2. **Integration with Hosted PostgreSQL:**
   - Connected Grafana to a hosted PostgreSQL server (`ep-gentle-block-a8z5hnmv-pooler.eastus2.azure.neon.tech`).
   - Configured Grafana to use the `grafana_metrics` table in the `neondb` database for metrics visualization.

3. **Database Table for Metrics:**
   - The `grafana_metrics` table was created in the hosted PostgreSQL server with the following schema:
     ```sql
     CREATE TABLE grafana_metrics (
         id SERIAL PRIMARY KEY,
         metric_name VARCHAR(255),
         metric_value FLOAT,
         timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
     ```

4. **Grafana Dashboard:**
   - Grafana is set up to visualize metrics stored in the `grafana_metrics` table.
